### PR TITLE
upgrade java, keycloak and jacoco

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM jelastic/maven:3.9.5-openjdk-21 AS build
+
+COPY src /app/src
+COPY pom.xml /app
+
+WORKDIR /app
+RUN mvn clean install -U
+
+
+FROM quay.io/keycloak/keycloak AS keycloak
+
+COPY --from=build /app/target/keycloak-extension-bundid-2.2.1-26.1-SNAPSHOT.jar /opt/keycloak/providers/keycloak-extension-bundid-2.2.1-26.1-SNAPSHOT.jar
+

--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,10 @@
     <description>Keycloak-Provider zur Anbindung an BundID</description>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <keycloak-version>26.1.1</keycloak-version>
+        <keycloak-version>26.1.2</keycloak-version>
         <auto-service.version>1.1.1</auto-service.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -184,7 +184,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.8</version>
+                    <version>0.8.12</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
Java 17 is deprecated on Keycloak: https://www.keycloak.org/docs/latest/release_notes/index.html#java-21-support

Switch to Java 21.